### PR TITLE
fix(plywood): docker image wasn't starting because of missing package.json

### DIFF
--- a/plywood/server/.dockerignore
+++ b/plywood/server/.dockerignore
@@ -1,2 +1,7 @@
 Dockerfile
 Jenkinsfile
+dist
+node_modules
+client/build
+client/node_modules
+

--- a/plywood/server/Dockerfile
+++ b/plywood/server/Dockerfile
@@ -20,6 +20,9 @@ FROM node:12.18.3-alpine
 RUN addgroup -S plywood && adduser -S plywood
 COPY --from=frontend-builder --chown=plywood /app/dist/ /app/dist/
 COPY --from=frontend-builder  --chown=plywood /app/node_modules/ /app/node_modules/
+COPY --from=frontend-builder --chown=plywood /app/package.json /app/package.json
+COPY --from=frontend-builder --chown=plywood   /app/client/build /app/client/build
+COPY --from=frontend-builder --chown=plywood   /app/client/package.json /app/client/package.json
 EXPOSE 3000
 WORKDIR /app
 USER plywood


### PR DESCRIPTION

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
The fix the dockerfile to include client build dir and package.json otherwise server is not able to start.