### PR TITLE
DR-189: fix dependabot pr builds

### DIFF
--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -3,6 +3,9 @@ on:
   workflow_call:
 
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   PythonLint:
     timeout-minutes: 5
@@ -26,7 +29,6 @@ jobs:
           ./bin/flake8_tests.sh
   PythonUnitTests:
     timeout-minutes: 60
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fix issue [DR-189](https://dataminelab.atlassian.net/browse/DR-189) related to https://github.com/marocchino/sticky-pull-request-comment/issues/298 when build is triggered by dependabot pr it doesn't have correct permissions

[DR-189]: https://dataminelab.atlassian.net/browse/DR-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ