### PR TITLE
fix: rename blacklist to blocklist for email domain validation

### DIFF
--- a/redash/handlers/users.py
+++ b/redash/handlers/users.py
@@ -1,4 +1,4 @@
-from disposable_email_domains import blacklist
+from disposable_email_domains import blocklist
 from flask import request
 from flask_login import current_user, login_user
 from flask_restful import abort
@@ -56,7 +56,7 @@ def require_allowed_email(email):
     # `example.com` and `example.com.` are equal - last dot stands for DNS root but usually is omitted
     _, domain = email.lower().rstrip(".").split("@", 1)
 
-    if domain in blacklist or domain in settings.BLOCKED_DOMAINS:
+    if domain in blocklist or domain in settings.BLOCKED_DOMAINS:
         abort(400, message="Bad email address.")
 
 


### PR DESCRIPTION
## What type of PR is this? 
I saw this error on vs-studio, it was weird that it didnt throw an error..
After testing manualy I figured that both `blacklist` and `blocklist` exists in the third party repo but it is not visible in the configs so was cousing troubles for vs code, this change fixed the issue

- [x] Refactor
- [ ] Bug Fix

## Description
`No name 'blacklist' in module 'disposable_email_domains'Pylint[E0611:no-name-in-module]`

## How is this tested?
- [x] Manually

## Related Tickets & Documents
https://pylint.readthedocs.io/en/latest/user_guide/messages/error/no-name-in-module.html
