### PR TITLE
refactor: add _sanitize_data function to handle NaN, Inf

### DIFF
--- a/redash/utils/__init__.py
+++ b/redash/utils/__init__.py
@@ -6,6 +6,7 @@ import decimal
 import hashlib
 import io
 import json
+import math
 import os
 import random
 import re
@@ -127,6 +128,17 @@ def json_loads(data, *args, **kwargs):
     return json.loads(data, *args, **kwargs)
 
 
+# Convert NaN, Inf, and -Inf to None, as they are not valid JSON values.
+def _sanitize_data(data):
+    if isinstance(data, dict):
+        return {k: _sanitize_data(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_sanitize_data(v) for v in data]
+    if isinstance(data, float) and (math.isnan(data) or math.isinf(data)):
+        return None
+    return data
+
+
 def json_dumps(data, *args, **kwargs):
     """A custom JSON dumping function which passes all parameters to the
     json.dumps function."""
@@ -135,7 +147,7 @@ def json_dumps(data, *args, **kwargs):
     # Float value nan or inf in Python should be render to None or null in json.
     # Using allow_nan = True will make Python render nan as NaN, leading to parse error in front-end
     kwargs.setdefault("allow_nan", False)
-    return json.dumps(data, *args, **kwargs)
+    return json.dumps(_sanitize_data(data), *args, **kwargs)
 
 
 def mustache_render(template, context=None, **kwargs):
@@ -244,8 +256,10 @@ def query_is_select_no_limit(query):
     if last_keyword_idx == -1 or parsed_query.tokens[0].value.upper() != "SELECT":
         return False
 
-    no_limit = parsed_query.tokens[last_keyword_idx].value.upper() != "LIMIT" \
-               and parsed_query.tokens[last_keyword_idx].value.upper() != "OFFSET"
+    no_limit = (
+        parsed_query.tokens[last_keyword_idx].value.upper() != "LIMIT"
+        and parsed_query.tokens[last_keyword_idx].value.upper() != "OFFSET"
+    )
     return no_limit
 
 
@@ -261,7 +275,7 @@ def add_limit_to_query(query):
     limit_tokens = sqlparse.parse(" LIMIT 1000")[0].tokens
     length = len(parsed_query.tokens)
     if parsed_query.tokens[length - 1].ttype == sqlparse.tokens.Punctuation:
-        parsed_query.tokens[length - 1:length - 1] = limit_tokens
+        parsed_query.tokens[length - 1 : length - 1] = limit_tokens
     else:
         parsed_query.tokens += limit_tokens
     return str(parsed_query)

--- a/tests/utils/test_json_dumps.py
+++ b/tests/utils/test_json_dumps.py
@@ -1,0 +1,31 @@
+from redash.utils import json_dumps, json_loads
+from tests import BaseTestCase
+
+
+class TestJsonDumps(BaseTestCase):
+    """
+    NaN, Inf, and -Inf are sanitized to None.
+    """
+
+    def test_data_with_nan_is_sanitized(self):
+        input_data = {
+            "columns": [
+                {"name": "_col0", "friendly_name": "_col0", "type": "float"},
+                {"name": "_col1", "friendly_name": "_col1", "type": "float"},
+                {"name": "_col2", "friendly_name": "_col1", "type": "float"},
+                {"name": "_col3", "friendly_name": "_col1", "type": "float"},
+            ],
+            "rows": [{"_col0": 1.0, "_col1": float("nan"), "_col2": float("inf"), "_col3": float("-inf")}],
+        }
+        expected_output_data = {
+            "columns": [
+                {"name": "_col0", "friendly_name": "_col0", "type": "float"},
+                {"name": "_col1", "friendly_name": "_col1", "type": "float"},
+                {"name": "_col2", "friendly_name": "_col1", "type": "float"},
+                {"name": "_col3", "friendly_name": "_col1", "type": "float"},
+            ],
+            "rows": [{"_col0": 1.0, "_col1": None, "_col2": None, "_col3": None}],
+        }
+        json_data = json_dumps(input_data)
+        actual_output_data = json_loads(json_data)
+        self.assertEquals(actual_output_data, expected_output_data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->
- [x] Bug Fix

## Description
When running query that output NaN, Infinite, or -Infinite, redash executor crashes with the error "Out of range float values are not JSON compliant" like below. Redash does not output any rows when the error was occurred.

```
[2025-02-19 04:48:49,040][PID:593][ERROR][rq.worker] [Job 6cfa1d1c-2a32-48c6-8bf4-0cd8f8ba6f32]: exception raised while executing (redash.tasks.queries.execution.execute_query)
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 1280, in perform
    self._result = self._execute()
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 1317, in _execute
    result = self.func(*self.args, **self.kwargs)
  File "/app/redash/tasks/queries/execution.py", line 309, in execute_query
    ).run()
  File "/app/redash/tasks/queries/execution.py", line 253, in run
    updated_query_ids = models.Query.update_latest_result(query_result)
  File "/app/redash/models/__init__.py", line 738, in update_latest_result
    for q in queries:
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 3534, in __iter__
    self.session._autoflush()
...
sqlalchemy.exc.StatementError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(builtins.ValueError) Out of range float values are not JSON compliant
[SQL: INSERT INTO query_results (org_id, data_source_id, query_hash, query, data, runtime, retrieved_at) VALUES (%(org_id)s, %(data_source_id)s, %(query_hash)s, %(query)s, %(data)s, %(runtime)s, %(retrieved_at)s) RETURNING query_results.id]
...
```