### PR TITLE
fix: reduce Sentry event volume to stay within free tier (DR-202)

### DIFF
--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -43,8 +43,18 @@ def setup_logging():
 
 setup_logging()
 
-redis_connection = redis.from_url(settings.REDIS_URL)
-rq_redis_connection = redis.from_url(settings.RQ_REDIS_URL)
+redis_connection = redis.from_url(
+    settings.REDIS_URL,
+    retry_on_timeout=True,
+    socket_keepalive=True,
+    health_check_interval=30,
+)
+rq_redis_connection = redis.from_url(
+    settings.RQ_REDIS_URL,
+    retry_on_timeout=True,
+    socket_keepalive=True,
+    health_check_interval=30,
+)
 mail = Mail()
 migrate = Migrate(compare_type=True)
 statsd_client = StatsClient(host=settings.STATSD_HOST, port=settings.STATSD_PORT, prefix=settings.STATSD_PREFIX)

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, MissingSchema
 from rq.timeouts import JobTimeoutException
 
 from redash import models, redis_connection, settings, statsd_client
@@ -185,6 +185,14 @@ def refresh_schema(data_source_id):
             time.time() - start_time,
         )
         statsd_client.incr("refresh_schema.connection_error")
+    except MissingSchema:
+        logger.warning(
+            "task=refresh_schema state=missing_url ds_id=%s ds_name=%s runtime=%.2f",
+            ds.id,
+            ds.name,
+            time.time() - start_time,
+        )
+        statsd_client.incr("refresh_schema.missing_url")
     except Exception:
         logger.warning("Failed refreshing schema for the data source: %s", ds.name, exc_info=1)
         statsd_client.incr("refresh_schema.error")


### PR DESCRIPTION
Add Redis connection resilience (retry_on_timeout, socket_keepalive, health_check_interval) to prevent ~48K/month ConnectionError events from idle disconnects. Add explicit MissingSchema handler in refresh_schema to catch data sources with null URLs (~2.8K events/month).

https://dataminelab.atlassian.net/browse/DR-202

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
