### PR TITLE
ci: pin GitHub Actions to SHAs for supply-chain hardening

### DIFF
--- a/.github/workflows/analyze-test-results.yaml
+++ b/.github/workflows/analyze-test-results.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download artifacts (for backup)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: e2e-test-results
           path: test-results/
@@ -59,7 +59,7 @@ jobs:
 
       - name: Add Artifact Links to PR (on failure)
         if: failure() && github.event_name == 'pull_request' && needs.frontend-unit-tests.result == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/periodic-snapshot.yaml
+++ b/.github/workflows/periodic-snapshot.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == github.event.repository.default_branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ssh-key: ${{ secrets.ACTION_PUSH_KEY }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - id: get-version
@@ -32,17 +32,17 @@ jobs:
     needs:
       - get_version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ secrets.GCR_URL }}
           username: ${{ secrets.GCR_USERNAME }}
           password: ${{ secrets.GCR_PASSWORD }}
       - name: Build and push datareporter
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: true
           tags: europe-west1-docker.pkg.dev/datareporter/datareporter/datareporter:${{needs.get_version.outputs.version}}
@@ -53,17 +53,17 @@ jobs:
     needs:
       - get_version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ secrets.GCR_URL }}
           username: ${{ secrets.GCR_USERNAME }}
           password: ${{ secrets.GCR_PASSWORD }}
       - name: Build and push plywood
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: true
           context: plywood
@@ -75,7 +75,7 @@ jobs:
       - build_datareporter
       - build_plywood
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Tag release

--- a/.github/workflows/restyled.yaml
+++ b/.github/workflows/restyled.yaml
@@ -17,14 +17,14 @@ jobs:
   restyled:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
 
-      - uses: restyled-io/actions/setup@v4
+      - uses: restyled-io/actions/setup@f31a2185676c560a98c4f9e0185e9bfe8ec3eaf9 # v4.4.24
 
       - id: restyler
-        uses: restyled-io/actions/run@v4
+        uses: restyled-io/actions/run@f31a2185676c560a98c4f9e0185e9bfe8ec3eaf9 # v4.4.24
         with:
           fail-on-differences: true
 
@@ -32,7 +32,7 @@ jobs:
           !cancelled() &&
           steps.restyler.outputs.success == 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           base: ${{ steps.restyler.outputs.restyled-base }}
           branch: ${{ steps.restyler.outputs.restyled-head }}

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -28,11 +28,11 @@ jobs:
       - if: github.event.pull_request.mergeable == 'false'
         name: Exit if PR is not mergeable
         run: exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10"
       - run: python -m ensurepip --upgrade
@@ -52,12 +52,12 @@ jobs:
       - if: github.event.pull_request.mergeable == 'false'
         name: Exit if PR is not mergeable
         run: exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           version: v0.17.0
       - name: Build docker Images
@@ -92,7 +92,7 @@ jobs:
           docker cp tests:/app/junit.xml ./results.xml
           ls -l
       - name: "Publish unit test report"
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: always()
         with:
           fail_on_failure: true
@@ -103,7 +103,7 @@ jobs:
           job_summary: true
           check_name: "Unit Tests Report"
       - name: Code Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: coverage.xml
           badge: true
@@ -115,7 +115,7 @@ jobs:
           output: both
           thresholds: "60 80"
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request'
         with:
           recreate: true
@@ -129,12 +129,12 @@ jobs:
       - if: github.event.pull_request.mergeable == 'false'
         name: Exit if PR is not mergeable
         run: exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -146,7 +146,7 @@ jobs:
         working-directory: client
         run: npm run lint
       - name: Store Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-test-results
           path: /tmp/test-results
@@ -158,17 +158,17 @@ jobs:
       - if: github.event.pull_request.mergeable == 'false'
         name: Exit if PR is not mergeable
         run: exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache npm dependencies
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/node_modules
           key: Linux-node-${{ hashFiles('client/package-lock.json') }}
@@ -244,12 +244,12 @@ jobs:
       - if: github.event.pull_request.mergeable == 'false'
         name: Exit if PR is not mergeable
         run: exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Enable Code Coverage Report For Develop Branch
@@ -397,7 +397,7 @@ jobs:
 
       - name: Upload Test Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-test-results
           path: test-artifacts/
@@ -405,7 +405,7 @@ jobs:
 
       - name: Analyze and Comment on Test Results
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Pins all 16 third-party actions across release.yaml, test-unit.yaml, analyze-test-results.yaml, periodic-snapshot.yaml, and restyled.yaml to specific commit SHAs (with version tag in trailing comment) to prevent supply-chain attacks via mutable tag references.

Pinned actions:
- actions/cache@v4 -> 0057852bfaa89a56745cba8c7296529d2fc39830 (v4.3.0)
- actions/checkout@v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5 (v4.3.1)
- actions/download-artifact@v4 -> d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4.3.0)
- actions/github-script@v7 -> f28e40c7f34bde8b3046d885e986cb6290c5673b (v7.1.0)
- actions/setup-node@v4 -> 49933ea5288caeca8642d1e84afbd3f7d6820020 (v4.4.0)
- actions/setup-python@v5 -> a26af69be951a213d495a4c3e4e4022e16d87065 (v5.6.0)
- actions/upload-artifact@v4 -> ea165f8d65b6e75b540449e92b4886f43607fa02 (v4.6.2)
- docker/build-push-action@v6 -> 10e90e3645eae34f1e60eeb005ba3a3d33f178e8 (v6.19.2)
- docker/login-action@v3 -> c94ce9fb468520275223c153574b00df6fe4bcc9 (v3.7.0)
- docker/setup-buildx-action@v3 -> 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f (v3.12.0)
- irongut/CodeCoverageSummary@v1.3.0 -> 51cc3a756ddcd398d447c044c02cb6aa83fdae95 (v1.3.0)
- marocchino/sticky-pull-request-comment@v2 -> 773744901bac0e8cbb5a0dc842800d45e9b2b405 (v2.9.4)
- mikepenz/action-junit-report@v4 -> db71d41eb79864e25ab0337e395c352e84523afe (v4.3.1)
- peter-evans/create-pull-request@v6 -> c5a7806660adbe173f04e3e038b0ccdcd758773c (v6.1.0)
- restyled-io/actions/run@v4 -> f31a2185676c560a98c4f9e0185e9bfe8ec3eaf9 (v4.4.24)
- restyled-io/actions/setup@v4 -> f31a2185676c560a98c4f9e0185e9bfe8ec3eaf9 (v4.4.24)

## What type of PR is this?

<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

<!-- If applicable, please include a link to your documentation PR against dataminelab/datareporter-docs -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
